### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Grouping keeps routine bumps to a few reviewable PRs. Security updates are
+      # unaffected: Dependabot raises those immediately and ungrouped.
+      dev-dependencies:
+        dependency-type: "development"
+      runtime-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Upgraded `cryptography` to 50.0.0, resolving GHSA-g6cj-pr64-35w5 (high).
+- Added a Dependabot config for `uv`, GitHub Actions and Docker. Routine bumps are grouped into a few weekly PRs; security updates stay immediate and ungrouped.
+
 ## [0.2.0] - 2026-08-05
 
 ### Added


### PR DESCRIPTION
The repo had no Dependabot config, so version updates were unscheduled and arrived as ungrouped one-off PRs.

Weekly updates for `uv`, GitHub Actions and Docker, grouped so routine bumps stay reviewable. Security updates are unaffected — Dependabot raises those immediately and ungrouped.

Also records the `cryptography` 50.0.0 upgrade (GHSA-g6cj-pr64-35w5) in the changelog; it merged via #40 without an entry.