### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-10
+
 ### Added
 
 - `--non-interactive` and `--yes` on the root command. `--non-interactive` never prompts and assumes the safe answer at each site; `--yes` affirms destructive ones and takes effect only alongside it, so `--yes` on its own cannot turn `vuln` into a one-liner. `exploit --mode demo` previously read stdin directly and ended the run on EOF under ssh or CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/kimera"]
 
 [project]
 name = "kimera"
-version = "0.2.0"
+version = "0.3.0"
 description = "Kubernetes Security Testing Toolkit"
 authors = [{name = "Dynatrace OSS", email = "opensource@dynatrace.com"}]
 license = "Apache-2.0"

--- a/src/kimera/__init__.py
+++ b/src/kimera/__init__.py
@@ -16,4 +16,7 @@
 
 """Kimera — Kubernetes Security Testing Toolkit."""
 
-__version__ = "2.0.0"
+from importlib.metadata import version
+
+# Derived from the package metadata so it cannot drift from pyproject.toml.
+__version__ = version("kimera")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib import metadata
+
 import kimera
 
 
@@ -19,9 +21,9 @@ class TestPackageStructure:
     """Test package structure and imports."""
 
     def test_package_version(self):
-        """Test package version is defined and correct."""
+        """Test package version is defined and matches the installed metadata."""
         assert hasattr(kimera, "__version__")
-        assert kimera.__version__ == "2.0.0"
+        assert kimera.__version__ == metadata.version("kimera")
         assert isinstance(kimera.__version__, str)
 
     def test_package_docstring(self):
@@ -87,10 +89,8 @@ class TestPackageMetadata:
             assert part.isdigit(), f"Version part '{part}' is not numeric"
 
     def test_version_consistency(self):
-        """Test version consistency across package files."""
-        # Version should match what's in pyproject.toml
-        package_version = kimera.__version__
-        assert package_version == "2.0.0"
+        """Test the exported version matches the packaged metadata from pyproject.toml."""
+        assert kimera.__version__ == metadata.version("kimera")
 
     def test_package_attributes(self):
         """Test that package has expected attributes."""

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "kimera"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cuts 0.3.0 — minor bump because the release carries two breaking changes: the `KIMERA_` environment variable prefix replacing `K8S_EXPLOIT_`, and the removal of `timeouts.operation`.

`__version__` now derives from the package metadata rather than a literal. It had drifted to `2.0.0`, left over from before the July reset to 0.x, while `pyproject.toml` said `0.2.0` — and `test_version_consistency` asserted the stale value under a docstring claiming it checked pyproject. Bumping `pyproject.toml` is now the only step a release needs.